### PR TITLE
add-close-tabs-from-sides - feat: Add direction parameter to closeNonActiveTabsInCurrentGroup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,23 @@ You can access the commands via the Command Palette (Ctrl+Shift+P (Windows) or C
     * macOS: `Ctrl ^`+`Cmd ⌘`+`Shift ⇧`+`W`
     * Other: `Ctrl ^`+`Super ❖`+`Shift ⇧`+`W`
 
-3. **Close other (non-active) tabs in each tab group**
+3. **Close other (non-active) tabs from left in current tab group**
+
+    Command: `Close other (non-active) tabs from left in current tab group`
+
+    Keybindings:
+    - macOS: `Ctrl ^`+`Cmd ⌘`+`Shift ⇧`+`Left Arrow ←`
+    - Other: `Ctrl ^`+`Super ❖`+`Shift ⇧`+`Left Arrow ←`
+
+4. **Close other (non-active) tabs from right in current tab group**
+
+    Command: `Close other (non-active) tabs from right in current tab group`
+
+    Keybindings:
+    - macOS: `Ctrl ^`+`Cmd ⌘`+`Shift ⇧`+`Right Arrow ←`
+    - Other: `Ctrl ^`+`Super ❖`+`Shift ⇧`+`Right Arrow ←`
+
+5. **Close other (non-active) tabs in each tab group**
 
     Command: `Close other (non-active) tabs in each tab group`
     
@@ -41,7 +57,7 @@ You can access the commands via the Command Palette (Ctrl+Shift+P (Windows) or C
     * macOS: `Ctrl ^`+`Option ⌥`+`Shift ⇧`+`W`
     * Other: `Ctrl ^`+`Alt ⎇`+`Shift ⇧`+`W`
 
-4. **Close other (non-active) tabs and tab groups everywhere**
+6. **Close other (non-active) tabs and tab groups everywhere**
 
     Command: `Close other (non-active) tabs and tab groups everywhere`
     

--- a/package.json
+++ b/package.json
@@ -29,6 +29,14 @@
         "title": "Close other (non-active) tabs in current tab group"
       },
       {
+        "command": "extension.closeNonActiveTabsFromLeftInCurrentGroup",
+        "title": "Close other (non-active) tabs from left in current tab group"
+      },
+      {
+        "command": "extension.closeNonActiveTabsFromRightInCurrentGroup",
+        "title": "Close other (non-active) tabs from right in current tab group"
+      },
+      {
         "command": "extension.closeNonActiveTabsInEachGroup",
         "title": "Close other (non-active) tabs in each tab group"
       },
@@ -48,6 +56,18 @@
         "command": "extension.closeNonActiveTabsInCurrentGroup",
         "key": "ctrl+super+shift+w",
         "mac": "ctrl+cmd+shift+w",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "extension.closeNonActiveTabsFromLeftInCurrentGroup",
+        "key": "ctrl+super+shift+left",
+        "mac": "ctrl+cmd+shift+left",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "extension.closeNonActiveTabsFromRightInCurrentGroup",
+        "key": "ctrl+super+shift+right",
+        "mac": "ctrl+cmd+shift+right",
         "when": "editorTextFocus"
       },
       {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -101,8 +101,82 @@ suite('Extension Test Suite', () => {
 
 		// Check to ensure non-active tabs were closed in the current tab group and not in other tab groups
 		assert.strictEqual(vscode.window.tabGroups.all.length, 3, 'There should be 3 tab groups');
-    assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 1, 'There should be 1 tab in the active group');
-    assert.strictEqual(vscode.window.tabGroups.all.filter(group => !group.activeTab).every(group => group.tabs.length === 2), true, 'Every non-active tab group should still have 2 tabs');
+    	assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 1, 'There should be 1 tab in the active group');
+    	assert.strictEqual(vscode.window.tabGroups.all.filter(group => !group.activeTab).every(group => group.tabs.length === 2), true, 'Every non-active tab group should still have 2 tabs');
+	});
+	
+	test('Close other (non-active) tabs from left in current tab group', async () => {
+		// Activate the extension
+		const extension = vscode.extensions.getExtension('dreamthinkbuild.close-other-tabs');
+		if (!extension) {
+			throw new Error('Extension not found');
+		}
+		await extension.activate();
+
+		// Open several documents
+		const doc1 = await vscode.workspace.openTextDocument({ content: 'Document 1' });
+		const doc2 = await vscode.workspace.openTextDocument({ content: 'Document 2' });
+		const doc3 = await vscode.workspace.openTextDocument({ content: 'Document 3' });
+		const doc4 = await vscode.workspace.openTextDocument({ content: 'Document 4' });
+		const doc5 = await vscode.workspace.openTextDocument({ content: 'Document 5' });
+		const doc6 = await vscode.workspace.openTextDocument({ content: 'Document 6' });
+		const allDocs = { doc1, doc2, doc3, doc4, doc5, doc6 };
+
+		// Show the documents in the editor
+		await vscode.window.showTextDocument(doc1, { viewColumn: vscode.ViewColumn.One });
+		await vscode.window.showTextDocument(doc2, { viewColumn: vscode.ViewColumn.One });
+		await vscode.window.showTextDocument(doc3, { viewColumn: vscode.ViewColumn.Two });
+		await vscode.window.showTextDocument(doc4, { viewColumn: vscode.ViewColumn.Two });
+		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Three });
+		await vscode.window.showTextDocument(doc6, { viewColumn: vscode.ViewColumn.Three });
+
+		// Set doc5 as the active document in the current tab group
+		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Two });
+
+		// Execute the command
+		await vscode.commands.executeCommand('extension.closeNonActiveTabsFromLeftInCurrentGroup');
+
+		// Check to ensure non-active tabs were closed in the current tab group and not in other tab groups
+		assert.strictEqual(vscode.window.tabGroups.all.length, 3, 'There should be 3 tab groups');
+    	assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 2, 'There should be 2 tabs in the active group');
+    	assert.strictEqual(vscode.window.tabGroups.all.filter(group => !group.activeTab).every(group => group.tabs.length === 2), true, 'Every non-active tab group should still have 2 tabs');
+	});
+	
+	test('Close other (non-active) tabs from right in current tab group', async () => {
+		// Activate the extension
+		const extension = vscode.extensions.getExtension('dreamthinkbuild.close-other-tabs');
+		if (!extension) {
+			throw new Error('Extension not found');
+		}
+		await extension.activate();
+
+		// Open several documents
+		const doc1 = await vscode.workspace.openTextDocument({ content: 'Document 1' });
+		const doc2 = await vscode.workspace.openTextDocument({ content: 'Document 2' });
+		const doc3 = await vscode.workspace.openTextDocument({ content: 'Document 3' });
+		const doc4 = await vscode.workspace.openTextDocument({ content: 'Document 4' });
+		const doc5 = await vscode.workspace.openTextDocument({ content: 'Document 5' });
+		const doc6 = await vscode.workspace.openTextDocument({ content: 'Document 6' });
+		const allDocs = { doc1, doc2, doc3, doc4, doc5, doc6 };
+
+		// Show the documents in the editor
+		await vscode.window.showTextDocument(doc1, { viewColumn: vscode.ViewColumn.One });
+		await vscode.window.showTextDocument(doc2, { viewColumn: vscode.ViewColumn.One });
+		await vscode.window.showTextDocument(doc3, { viewColumn: vscode.ViewColumn.Two });
+		await vscode.window.showTextDocument(doc4, { viewColumn: vscode.ViewColumn.Two });
+		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Three });
+		await vscode.window.showTextDocument(doc6, { viewColumn: vscode.ViewColumn.Three });
+
+		// Set doc5 as the active document in the current tab group
+		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Two });
+
+		// Execute the command
+		await vscode.commands.executeCommand('extension.closeNonActiveTabsFromRightInCurrentGroup');
+
+		// Check to ensure non-active tabs were closed in the current tab group and not in other tab groups
+		assert.strictEqual(vscode.window.tabGroups.all.length, 3, 'There should be 3 tab groups');
+    	assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 5, 'There should be 5 tabs in the active group');
+    	assert.strictEqual(vscode.window.tabGroups.all.filter(group => !group.activeTab).every(group => group.tabs.length === 2), true, 'Every non-active tab group should still have 2 tabs');
 	});
 
 	test('Close other (non-active) tabs in each tab group', async () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -138,7 +138,7 @@ suite('Extension Test Suite', () => {
 
 		// Check to ensure non-active tabs were closed in the current tab group and not in other tab groups
 		assert.strictEqual(vscode.window.tabGroups.all.length, 3, 'There should be 3 tab groups');
-    	assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 2, 'There should be 5 tabs in the active group');
+    	assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 2, 'There should be 2 tabs in the active group');
     	assert.strictEqual(vscode.window.tabGroups.all.filter(group => !group.activeTab).every(group => group.tabs.length === 3), true, 'Every non-active tab group should still have 3 tabs');
 	});
 	

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -125,10 +125,10 @@ suite('Extension Test Suite', () => {
 		// Show the documents in the editor
 		await vscode.window.showTextDocument(doc1, { viewColumn: vscode.ViewColumn.One });
 		await vscode.window.showTextDocument(doc2, { viewColumn: vscode.ViewColumn.One });
-		await vscode.window.showTextDocument(doc3, { viewColumn: vscode.ViewColumn.Two });
+		await vscode.window.showTextDocument(doc3, { viewColumn: vscode.ViewColumn.One });
 		await vscode.window.showTextDocument(doc4, { viewColumn: vscode.ViewColumn.Two });
-		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Three });
-		await vscode.window.showTextDocument(doc6, { viewColumn: vscode.ViewColumn.Three });
+		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Two });
+		await vscode.window.showTextDocument(doc6, { viewColumn: vscode.ViewColumn.Two });
 
 		// Set doc5 as the active document in the current tab group
 		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Two });
@@ -138,8 +138,8 @@ suite('Extension Test Suite', () => {
 
 		// Check to ensure non-active tabs were closed in the current tab group and not in other tab groups
 		assert.strictEqual(vscode.window.tabGroups.all.length, 3, 'There should be 3 tab groups');
-    	assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 2, 'There should be 2 tabs in the active group');
-    	assert.strictEqual(vscode.window.tabGroups.all.filter(group => !group.activeTab).every(group => group.tabs.length === 2), true, 'Every non-active tab group should still have 2 tabs');
+    	assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 2, 'There should be 5 tabs in the active group');
+    	assert.strictEqual(vscode.window.tabGroups.all.filter(group => !group.activeTab).every(group => group.tabs.length === 3), true, 'Every non-active tab group should still have 3 tabs');
 	});
 	
 	test('Close other (non-active) tabs from right in current tab group', async () => {
@@ -162,10 +162,10 @@ suite('Extension Test Suite', () => {
 		// Show the documents in the editor
 		await vscode.window.showTextDocument(doc1, { viewColumn: vscode.ViewColumn.One });
 		await vscode.window.showTextDocument(doc2, { viewColumn: vscode.ViewColumn.One });
-		await vscode.window.showTextDocument(doc3, { viewColumn: vscode.ViewColumn.Two });
+		await vscode.window.showTextDocument(doc3, { viewColumn: vscode.ViewColumn.One });
 		await vscode.window.showTextDocument(doc4, { viewColumn: vscode.ViewColumn.Two });
-		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Three });
-		await vscode.window.showTextDocument(doc6, { viewColumn: vscode.ViewColumn.Three });
+		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Two });
+		await vscode.window.showTextDocument(doc6, { viewColumn: vscode.ViewColumn.Two });
 
 		// Set doc5 as the active document in the current tab group
 		await vscode.window.showTextDocument(doc5, { viewColumn: vscode.ViewColumn.Two });
@@ -175,8 +175,8 @@ suite('Extension Test Suite', () => {
 
 		// Check to ensure non-active tabs were closed in the current tab group and not in other tab groups
 		assert.strictEqual(vscode.window.tabGroups.all.length, 3, 'There should be 3 tab groups');
-    	assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 5, 'There should be 5 tabs in the active group');
-    	assert.strictEqual(vscode.window.tabGroups.all.filter(group => !group.activeTab).every(group => group.tabs.length === 2), true, 'Every non-active tab group should still have 2 tabs');
+    	assert.strictEqual(vscode.window.tabGroups.activeTabGroup.tabs.length, 2, 'There should be 2 tabs in the active group');
+    	assert.strictEqual(vscode.window.tabGroups.all.filter(group => !group.activeTab).every(group => group.tabs.length === 3), true, 'Every non-active tab group should still have 3 tabs');
 	});
 
 	test('Close other (non-active) tabs in each tab group', async () => {


### PR DESCRIPTION
# Description
This pull request introduces a new parameter to the closeNonActiveTabsInCurrentGroup function, enhancing its functionality to allow more flexible tab management.

# Changes Made
Added direction Parameter:
 - Introduced a new parameter named direction of type CloseDirection with a default value of CloseDirection.both.
 - The direction parameter determines which tabs will be closed:
  - CloseDirection.left to close tabs to the left of the active tab.
  - CloseDirection.right to close tabs to the right of the active tab.
  - CloseDirection.both to close tabs on both sides of the active tab (default behavior).
  
  Please review the changes and let me know if you have any suggestions or feedback. Thank you!